### PR TITLE
Avoid double-escape for all characters, not just <

### DIFF
--- a/src/utils/markodown-loader.js
+++ b/src/utils/markodown-loader.js
@@ -46,7 +46,7 @@ module.exports = function markodown(source) {
       .replace(/\s+\([^\)]+\)/g, "")
       .replace(/\([^\)]+\)/g, "()")
       .replace(/<\/?code\>/g, "")
-      .replace(/&amp;lt;/g, "&lt;");
+      .replace(/&amp;([a-z0-9]+?);/g, "&$1;");
 
     title = title || linkText;
 


### PR DESCRIPTION
Obsoletes #43, fixes the same problem as described in it.

Right now I’m double-checking if this has any side-effects other than `&amp;amp;` and `&amp;lt;`, but that weird bug where `npm run build` doesn’t like being repeated is slowing that down. Pushing this up in case either of y’all have a smarter way of checking.