### PR TITLE
Update marko𐲦master refs to marko𐲦main

### DIFF
--- a/src/components/app-footer/index.marko
+++ b/src/components/app-footer/index.marko
@@ -4,7 +4,7 @@
         <span><span.bold>OpenJS</span>&nbsp;<span.light>Foundation</span></span>
     </a>
     <div.separator/>
-    <a.osi href="https://github.com/marko-js/marko/blob/master/LICENSE">
+    <a.osi href="https://github.com/marko-js/marko/blob/main/LICENSE">
         <img src="./osi.svg" alt=""/>
         MIT&nbsp;License
     </a>

--- a/src/pages/docs/[name]/components/contributors/index.marko
+++ b/src/pages/docs/[name]/components/contributors/index.marko
@@ -1,6 +1,6 @@
 import getContributors from "./get-contributors";
 
-$ var editPath = `https://github.com/${input.repo}/blob/master/${input.repoPath}`;
+$ var editPath = `https://github.com/${input.repo}/blob/main/${input.repoPath}`;
 
 style {
     .contributors {

--- a/src/pages/docs/[name]/components/edit-on-github/index.marko
+++ b/src/pages/docs/[name]/components/edit-on-github/index.marko
@@ -1,4 +1,4 @@
-<a.edit-on-github href=`https://github.com/${input.repo}/blob/master/${input.repoPath}`>
+<a.edit-on-github href=`https://github.com/${input.repo}/blob/main/${input.repoPath}`>
     EDIT <img src="./github.svg"/>
 </a>
 


### PR DESCRIPTION
Mostly serves to fix the redirect notice appearing when using the “Edit on GitHub” links:

![A blue dialog reading ”Branch master was renamed to main.”](https://user-images.githubusercontent.com/8072522/177838576-92b2f5d2-236a-4059-b427-283223105787.png)
