### PR TITLE
Fix up `alt` text across website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://user-images.githubusercontent.com/1958812/62652399-2a314c80-b910-11e9-883b-196686708979.png"/>
+![Screenshot of markojs.com running in a browser](https://user-images.githubusercontent.com/1958812/62652399-2a314c80-b910-11e9-883b-196686708979.png)
 
 ## Running markojs.com Locally
 

--- a/src/pages/docs/[name]/components/contributors/index.marko
+++ b/src/pages/docs/[name]/components/contributors/index.marko
@@ -60,7 +60,7 @@ style {
         <div.contributors>
             <for|contributor| of=contributors>
                 <a.contributor href=contributor.profile>
-                    <img.photo src=contributor.photo/>
+                    <img.photo src=contributor.photo alt=""/>
                     <span.name>${contributor.username}</span>
                 </a>
             </for>

--- a/src/pages/docs/[name]/components/edit-on-github/index.marko
+++ b/src/pages/docs/[name]/components/edit-on-github/index.marko
@@ -1,22 +1,19 @@
 <a.edit-on-github href=`https://github.com/${input.repo}/blob/main/${input.repoPath}`>
-    EDIT <img src="./github.svg"/>
+    EDIT <img alt="on GitHub" src="./github.svg"/>
 </a>
 
 style {
     .edit-on-github {
-        display:flex;
-        justify-content:center;
-        align-items:center;
         position: absolute;
-        top:0.25em; right:0;
+        top: 0.25em; right: 0;
         font-size: 0.8em;
-        color:#a4a6a8;
-        font-weight:600;
+        color: #a4a6a8;
+        font-weight: 600;
     }
 
-    .edit-on-github img {
-        margin-left:0.5em;
-        height:1.2em;
-        filter:contrast(0) brightness(1.25);
+    .edit-on-github > img {
+        height: 1.2em;
+        vertical-align: -0.2em;
+        opacity: 0.35;
     }
 }

--- a/src/pages/index/components/home-demo-page/index.marko
+++ b/src/pages/index/components/home-demo-page/index.marko
@@ -227,7 +227,7 @@ $ const progress = input.buffered ? Math.floor(input.progress / 0.9) : input.pro
       <div.demo-page-cart.demo-page-delay-4.demo-page-hydrated>Cart (0)</div>
     </div>
     <div.demo-page-product.demo-page-delay-5 class={ "demo-page-loading": progress < 0.4 }>
-      <img.demo-page-image class={ "demo-page-lowres": progress < 0.6 || (input.buffered && input.progress < 1) } src="./product.png"/>
+      <img.demo-page-image class={ "demo-page-lowres": progress < 0.6 || (input.buffered && input.progress < 1) } src="./product.png" alt=""/>
       <div.demo-page-description.demo-page-delay-6>
         <span.demo-page-description-title>Google Home - $79</span>
         <div.demo-page-description-button.demo-page-delay-7.demo-page-hydrated>Add to Cart</div>

--- a/src/pages/index/components/home-performance/index.marko
+++ b/src/pages/index/components/home-performance/index.marko
@@ -5,14 +5,14 @@
   </@content>
   <@visual>
       <div.home-performance-example role="img" aria-label="Marko templates are compiled to generate HTML Strings on the server and VDOM Nodes in the browser">
-          <div.home-performance-input role="presentation">
+          <div.home-performance-input>
             <code-block lang="marko" no-switch>
                 <div>
                   <h2>Images</h2>
                   <div>
                     <for|item| of=input.items>
                       <div on-click(() => alert(item.title), item)>
-                        <img src=item.img />
+                        <img src=item.img alt="" />
                       </div>
                     </for>
                   </div>
@@ -22,7 +22,7 @@
           <div.home-performance-arrow>
             <img src="./arrow.svg" alt=""/>
           </div>
-          <div.home-performance-outputs role="presentation">
+          <div.home-performance-outputs>
             <div.home-performance-html>
               <code-block lang="javascript" no-switch>
                   out.write("<div><h2>Images</h2><div>");

--- a/src/pages/index/components/home-tooling/index.marko
+++ b/src/pages/index/components/home-tooling/index.marko
@@ -3,7 +3,7 @@
     <@content>
         <p>
             Marko provides
-            <a href="https://marketplace.visualstudio.com/items?itemName=Marko-JS.marko-vscode" alt="Marko VSCode Extension">
+            <a href="https://marketplace.visualstudio.com/items?itemName=Marko-JS.marko-vscode" title="Marko VSCode Extension">
                 first-class support
             </a>
             for the VSCode editor including syntax highlighting, Autocompletion,


### PR DESCRIPTION
- Missing `alt` in README, contributor banner, and Edit on GitHub
- Tweaked Edit on GitHub to not use `filter`, simpler CSS overall
- The missing `alt` attributes in the demo illustrations don’t matter for accessibility because the ancestor `role="img"` doesn’t expose children, but a11y checkers/the validator were complaining so it doesn’t hurt to add
- `role="presentation"` on a `<div>` is redundant
- Fixed typo of `alt` on `<a>` in `home-tooling/index.marko`