### PR TITLE
Add skip link for a11y

### DIFF
--- a/src/components/app-layout/components/skip-link/index.marko
+++ b/src/components/app-layout/components/skip-link/index.marko
@@ -1,0 +1,34 @@
+<a#skip-link href=`#${input.anchor}`>
+  Skip to main content
+</a>
+
+style {
+  /* This positions the skip link off-page accessibly, and transitions it in noticeably when it receives focus.
+     More info: https://webaim.org/techniques/skipnav/
+  */
+   #skip-link { /* Intentionally using an id for specificity reasons */
+    position: fixed;
+    z-index: 10000000;
+    left: 0;
+    top: -4em; /* Fallback for browsers without `transform` support */
+    padding: 0.4em;
+    background: #fff;
+    border: 2px solid hsl(0, 0%, 25%);
+    border-bottom-right-radius: 0.25em;
+    text-decoration: underline; /* Not a fan of how this is removed for all links by default */
+    transform: translateY(-100%);
+    transition: transform 0.2s, 
+                top 0s; /* Don’t animate this it’s janky */
+    transition-delay: 0.3s; /* A delay that’s removed on :focus makes the link linger a bit when tabbing away, in case the user didn’t expect it while mashing Tab */
+  }
+   #skip-link:focus {
+    top: 0;
+    transform: translateY(0);
+    transition-delay: 0s; /* See above note */
+  }
+  @media print {
+    #skip-link {
+      display: none !important;
+    }
+  }
+}

--- a/src/components/app-layout/components/skip-link/index.marko
+++ b/src/components/app-layout/components/skip-link/index.marko
@@ -34,23 +34,4 @@ style {
       display: none !important;
     }
   }
-
-  #skiptocontent a {
-    padding: 6px;
-    position: absolute;
-    top: -40px;
-    left: 0;
-    color:white;
-    border-right: 1px solid white;
-    border-bottom:1px solid white;
-    border-bottom-right-radius:8px;
-    background:#BF1722;
-    transition: top 1s ease-out;
-    z-index: 100;
-  }
-
-  #skiptocontent a:focus {
-    top: 0;
-    transition: top .1s ease-in;
-  }
 }

--- a/src/components/app-layout/components/skip-link/index.marko
+++ b/src/components/app-layout/components/skip-link/index.marko
@@ -11,24 +11,46 @@ style {
     z-index: 10000000;
     left: 0;
     top: -4em; /* Fallback for browsers without `transform` support */
-    padding: 0.4em;
+    padding: 0.2em;
     background: #fff;
     border: 2px solid hsl(0, 0%, 25%);
     border-bottom-right-radius: 0.25em;
-    text-decoration: underline; /* Not a fan of how this is removed for all links by default */
+    text-decoration: underline; /* Not a fan of how we remove this for all links by default */
     transform: translateY(-100%);
-    transition: transform 0.2s, 
-                top 0s; /* Don’t animate this it’s janky */
-    transition-delay: 0.3s; /* A delay that’s removed on :focus makes the link linger a bit when tabbing away, in case the user didn’t expect it while mashing Tab. https://css-tricks.com/transition-delay-delays/ */
+    transition: top 1s steps(1), transform 1s; /* Long duration for focusing out to make the skip link harder to miss, as described in the WebAIM link */
   }
    #skip-link:focus {
     top: 0;
     transform: translateY(0);
-    transition-delay: 0s; /* See above note */
+    transition-duration: 0.01ms, 0.2s; /* See above note */
+  }
+  @media (prefers-reduced-motion) {
+    #skip-link {
+      transition-duration: 0.01ms !important;
+    }
   }
   @media print {
     #skip-link {
       display: none !important;
     }
+  }
+
+  #skiptocontent a {
+    padding: 6px;
+    position: absolute;
+    top: -40px;
+    left: 0;
+    color:white;
+    border-right: 1px solid white;
+    border-bottom:1px solid white;
+    border-bottom-right-radius:8px;
+    background:#BF1722;
+    transition: top 1s ease-out;
+    z-index: 100;
+  }
+
+  #skiptocontent a:focus {
+    top: 0;
+    transition: top .1s ease-in;
   }
 }

--- a/src/components/app-layout/components/skip-link/index.marko
+++ b/src/components/app-layout/components/skip-link/index.marko
@@ -19,7 +19,7 @@ style {
     transform: translateY(-100%);
     transition: transform 0.2s, 
                 top 0s; /* Don’t animate this it’s janky */
-    transition-delay: 0.3s; /* A delay that’s removed on :focus makes the link linger a bit when tabbing away, in case the user didn’t expect it while mashing Tab */
+    transition-delay: 0.3s; /* A delay that’s removed on :focus makes the link linger a bit when tabbing away, in case the user didn’t expect it while mashing Tab. https://css-tricks.com/transition-delay-delays/ */
   }
    #skip-link:focus {
     top: 0;

--- a/src/components/app-layout/index.marko
+++ b/src/components/app-layout/index.marko
@@ -1,3 +1,5 @@
+static const mainContentId = 'main';
+
 <!doctype html>
 <html lang="en">
   <head>
@@ -15,9 +17,10 @@
     </script>
   </head>
   <body class=input.class>
+    <skip-link anchor=mainContentId/>
     <layout-header/>
     <layout-sidebar currentDoc=input.currentDoc toc=input.toc/>
-    <main.content>
+    <main.content id=mainContentId tabindex=-1>
       <${input.renderBody}/>
     </main>
     <if(input.footer !== false)>


### PR DESCRIPTION
Pinging @ianmcburnie for an accessibility once-over in case I missed something

Screenshot of expected rendering when focused:

![Link reading “Skip to main content”. Appears in the upper-left corner with black text, a dark gray border, a white background, and a browser-default focus outline.](https://user-images.githubusercontent.com/8072522/178805212-41cf76de-a601-4704-a0e5-29e53b7e1d79.png)
