### PR TITLE
Oops, allow multiword searches

### DIFF
--- a/src/components/app-layout/components/layout-search/index.marko
+++ b/src/components/app-layout/components/layout-search/index.marko
@@ -7,7 +7,7 @@
   <input.SiteSearch-input name="q"
     type="search"
     placeholder="search docs…"
-    pattern=/\s*?\S+\s*?/ title="Enter something to search for"
+    pattern=/.*?\S+.*?/ title="Enter something to search for"
     required autocapitalize="off"
   />
   <button.SiteSearch-submit name="q" value="site:markojs.com">


### PR DESCRIPTION
I am bad at regex. The previous one blocked searches like “split components”, as @DylanPiercey found out:

![Screenshot of a search for “… components” showing a validation bubble reading “Match the requested format” in Safari.](https://cdn.discordapp.com/attachments/725021901457457193/1011693282797027420/unknown.png)

Also cool to know Safari doesn’t follow the spec showing the `title` attribute text for `pattern` mismatches.