### PR TITLE
Make pics of contributors active

### DIFF
--- a/src/pages/index/components/home-community/index.marko
+++ b/src/pages/index/components/home-community/index.marko
@@ -38,7 +38,7 @@ import ghGot from "gh-got";
             <await(ghGot('/repos/marko-js/marko/contributors?per_page=100'))>
                 <@then|{ body }|>
                     <for|contributor| of=body>
-                        <img src=`${contributor.avatar_url}&s=64` alt=contributor.login loading="lazy"/>
+                        <a href=contributor.html_url><img src=`${contributor.avatar_url}&s=64` alt=contributor.login loading="lazy"/></a>
                     </for>
                 </@then>
             </await>


### PR DESCRIPTION
So, visitors will be able to proceed to contributors' GitHub-profiles. The change applies to the [Marko's main page](https://markojs.com/), at the bottom of the site (where the “wall of images” appears, of the Community section).

But be careful: I have not tested it!